### PR TITLE
feat: add volume control for sound notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ npx ccnoti -d -m "Task complete"     # Desktop notification (with sound)
 npx ccnoti -d -v  -m "All tests pass" # Sound + Desktop notification
 npx ccnoti -v -m "Deploy complete"   # Voice only
 npx ccnoti -s                        # Sound only
+npx ccnoti -s -V 0.3                # Sound with low volume (30%)
+npx ccnoti -s -V 1.0                # Sound with max volume
 ```
 
 ## Command Line Options
@@ -36,6 +38,7 @@ npx ccnoti -s                        # Sound only
 | `--voice` | `-v` | Enable text-to-speech | `--voice` |
 | `--desktop` | `-d` | Show Desktop notification | `--desktop` |
 | `--soundFile <path>` | - | Sound file path to play | `--soundFile=/System/Library/Sounds/Glass.aiff` |
+| `--volume <num>` | `-V` | Sound volume (0.0-1.0) | `--volume 0.5` |
 | `--message <text>` | `-m` | Notification message text | `--message "Task done"` |
 | `--config <path>` | `-c` | Path to config file | `--config my-config.json` |
 
@@ -48,7 +51,8 @@ Create a `.ccnotirc` file in your project root (automatically loaded):
   "sound": true,
   "voice": true,
   "desktop": false,
-  "soundFile": "/System/Library/Sounds/Glass.aiff"
+  "soundFile": "/System/Library/Sounds/Glass.aiff",
+  "volume": 0.5
 }
 ```
 

--- a/e2e/test-basic.sh
+++ b/e2e/test-basic.sh
@@ -22,6 +22,26 @@ $CCNOTI --sound --soundFile=/System/Library/Sounds/Ping.aiff
 echo
 read -p "Enterキーを押して続行..." -r
 
+echo "# 音量指定（小音量 0.1）"
+$CCNOTI --sound --volume 0.1
+echo
+read -p "Enterキーを押して続行..." -r
+
+echo "# 音量指定（デフォルト 0.5）"
+$CCNOTI --sound --volume 0.5
+echo
+read -p "Enterキーを押して続行..." -r
+
+echo "# 音量指定（大音量 1.0）"
+$CCNOTI --sound --volume 1.0
+echo
+read -p "Enterキーを押して続行..." -r
+
+echo "# 音量指定（範囲外 - 警告が出るはず）"
+$CCNOTI --sound --volume 1.5
+echo
+read -p "Enterキーを押して続行..." -r
+
 echo "# 音声読み上げ"
 $CCNOTI --voice --message="テスト音声"
 echo

--- a/e2e/test-combinations.sh
+++ b/e2e/test-combinations.sh
@@ -35,5 +35,20 @@ read -p "Enterキーを押して続行..." -r
 echo "# 日本語で全機能"
 $CCNOTI --sound --voice --desktop --message="テスト完了"
 echo
+read -p "Enterキーを押して続行..." -r
+
+echo "# 小音量効果音＋通知"
+$CCNOTI --sound --volume 0.2 --desktop --message="小音量テスト"
+echo
+read -p "Enterキーを押して続行..." -r
+
+echo "# 大音量効果音＋音声＋通知"
+$CCNOTI --sound --volume 0.9 --voice --desktop --message="大音量で全機能"
+echo
+read -p "Enterキーを押して続行..." -r
+
+echo "# カスタム効果音＋音量指定"
+$CCNOTI --sound --soundFile=/System/Library/Sounds/Glass.aiff --volume 0.3 --message="カスタム音量"
+echo
 
 echo "完了"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -11,6 +11,7 @@ import { getDefaultSoundFile } from "./default-sounds";
 export const defaultConfig: Options = {
   sound: false,
   soundFile: getDefaultSoundFile(),
+  volume: 0.5,
   voice: false,
   desktop: false,
 };

--- a/src/lib/notify-sound.ts
+++ b/src/lib/notify-sound.ts
@@ -17,8 +17,15 @@ export async function notifySound(
       throw new Error(`Sound file not found: ${options.soundFile}`);
     }
 
+    // 音量の検証とデフォルト値の設定
+    let volume = options.volume ?? 0.5;
+    if (volume < 0.0 || volume > 1.0) {
+      consola.warn(`Invalid volume ${volume}. Using default volume 0.5`);
+      volume = 0.5;
+    }
+
     // sound-playで再生
-    await sound.play(options.soundFile);
+    await sound.play(options.soundFile, volume);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     consola.error(message);

--- a/src/lib/option.ts
+++ b/src/lib/option.ts
@@ -1,4 +1,5 @@
 import defu from "defu";
+import { consola } from "consola";
 import { Options, PartialOptions } from "../types";
 
 /**
@@ -10,5 +11,14 @@ import { Options, PartialOptions } from "../types";
  */
 export function resolveOption(config: Options, args: PartialOptions): Options {
   const options = defu(args, config);
+  
+  // 音量の検証
+  if (options.volume !== undefined && options.volume !== null) {
+    if (options.volume < 0.0 || options.volume > 1.0) {
+      consola.warn(`Invalid volume ${options.volume} in configuration. Using default volume 0.5`);
+      options.volume = 0.5;
+    }
+  }
+  
   return options as Options;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface Options {
   sound: boolean;
   /** Path to the sound file to play */
   soundFile: string;
+  /** Sound volume (0.0-1.0) */
+  volume?: number;
   /** Whether to use text-to-speech */
   voice: boolean;
   /** Whether to show a system notification */

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -32,6 +32,7 @@ describe("config", () => {
       expect(defaultConfig).toEqual({
         sound: false,
         soundFile: "/System/Library/Sounds/Glass.aiff",
+        volume: 0.5,
         voice: false,
         desktop: false,
       });
@@ -82,6 +83,7 @@ describe("config", () => {
       expect(result).toEqual({
         sound: true,
         soundFile: "/System/Library/Sounds/Glass.aiff",
+        volume: 0.5,
         voice: true,
         desktop: false,
       });
@@ -197,6 +199,7 @@ describe("config", () => {
       expect(result).toEqual({
         sound: true,
         soundFile: "/System/Library/Sounds/Glass.aiff", // From default
+        volume: 0.5, // From default
         voice: false, // From default
         desktop: true,
         message: "This is a complex test message",

--- a/tests/notify-sound.test.ts
+++ b/tests/notify-sound.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { notifySound } from "../src/lib/notify-sound";
+import { Options } from "../src/types";
+import { consola } from "consola";
+
+// Mock dependencies
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("sound-play", () => ({
+  default: {
+    play: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { existsSync } from "fs";
+import sound from "sound-play";
+
+describe("notifySound", () => {
+  const mockSound = vi.mocked(sound);
+  const mockExistsSync = vi.mocked(existsSync);
+  let mockConsola: any;
+  let mockConsolaError: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(true);
+    mockConsola = vi.spyOn(consola, "warn").mockImplementation(() => {});
+    mockConsolaError = vi.spyOn(consola, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("volume handling", () => {
+    it("should use provided volume when valid", async () => {
+      const options: Options = {
+        sound: true,
+        soundFile: "/test.aiff",
+        volume: 0.3,
+        voice: false,
+        desktop: false,
+      };
+
+      await notifySound(options);
+
+      expect(mockSound.play).toHaveBeenCalledWith("/test.aiff", 0.3);
+      expect(mockConsola).not.toHaveBeenCalled();
+    });
+
+    it("should use default volume when not provided", async () => {
+      const options: Options = {
+        sound: true,
+        soundFile: "/test.aiff",
+        voice: false,
+        desktop: false,
+      };
+
+      await notifySound(options);
+
+      expect(mockSound.play).toHaveBeenCalledWith("/test.aiff", 0.5);
+      expect(mockConsola).not.toHaveBeenCalled();
+    });
+
+    it("should warn and use default when volume is less than 0", async () => {
+      const options: Options = {
+        sound: true,
+        soundFile: "/test.aiff",
+        volume: -0.5,
+        voice: false,
+        desktop: false,
+      };
+
+      await notifySound(options);
+
+      expect(mockConsola).toHaveBeenCalledWith(
+        "Invalid volume -0.5. Using default volume 0.5"
+      );
+      expect(mockSound.play).toHaveBeenCalledWith("/test.aiff", 0.5);
+    });
+
+    it("should warn and use default when volume is greater than 1", async () => {
+      const options: Options = {
+        sound: true,
+        soundFile: "/test.aiff",
+        volume: 1.5,
+        voice: false,
+        desktop: false,
+      };
+
+      await notifySound(options);
+
+      expect(mockConsola).toHaveBeenCalledWith(
+        "Invalid volume 1.5. Using default volume 0.5"
+      );
+      expect(mockSound.play).toHaveBeenCalledWith("/test.aiff", 0.5);
+    });
+
+    it("should accept boundary values", async () => {
+      const options1: Options = {
+        sound: true,
+        soundFile: "/test.aiff",
+        volume: 0.0,
+        voice: false,
+        desktop: false,
+      };
+
+      await notifySound(options1);
+      expect(mockSound.play).toHaveBeenCalledWith("/test.aiff", 0.0);
+
+      const options2: Options = {
+        sound: true,
+        soundFile: "/test.aiff",
+        volume: 1.0,
+        voice: false,
+        desktop: false,
+      };
+
+      await notifySound(options2);
+      expect(mockSound.play).toHaveBeenCalledWith("/test.aiff", 1.0);
+      expect(mockConsola).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should return early when soundFile is empty", async () => {
+      const options: Options = {
+        sound: true,
+        soundFile: "",
+        voice: false,
+        desktop: false,
+      };
+
+      const result = await notifySound(options);
+
+      expect(result).toBeUndefined();
+      expect(mockSound.play).not.toHaveBeenCalled();
+    });
+
+    it("should return error when file does not exist", async () => {
+      mockExistsSync.mockReturnValue(false);
+      const options: Options = {
+        sound: true,
+        soundFile: "/nonexistent.aiff",
+        voice: false,
+        desktop: false,
+      };
+
+      const result = await notifySound(options);
+
+      expect(result).toBe(
+        "Sound error: Sound file not found: /nonexistent.aiff"
+      );
+      expect(mockConsolaError).toHaveBeenCalledWith(
+        "Sound file not found: /nonexistent.aiff"
+      );
+      expect(mockSound.play).not.toHaveBeenCalled();
+    });
+
+    it("should handle sound.play errors", async () => {
+      mockSound.play.mockRejectedValueOnce(new Error("Play failed"));
+      const options: Options = {
+        sound: true,
+        soundFile: "/test.aiff",
+        voice: false,
+        desktop: false,
+      };
+
+      const result = await notifySound(options);
+
+      expect(result).toBe("Sound error: Play failed");
+      expect(mockConsolaError).toHaveBeenCalledWith("Play failed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `--volume`/`-V` CLI option to control sound playback volume (0.0-1.0)
- Implemented volume validation with warnings for out-of-range values
- Added volume property support in configuration files

Fixes #1 

## Changes
- **CLI**: New `--volume`/`-V` option with proper type conversion
- **Config**: Volume property in `.ccnotirc` configuration file
- **Validation**: Automatic fallback to default (0.5) for invalid values
- **Tests**: Comprehensive unit tests for volume functionality
- **E2E**: Interactive tests for various volume scenarios
- **Docs**: Updated README with volume usage examples

## Test plan
- [x] Unit tests for volume validation and edge cases
- [x] E2E tests for volume control with different values
- [x] Manual testing with various volume levels (0.0, 0.5, 1.0)
- [x] Configuration file volume property loading
- [x] CLI argument priority over config file values
